### PR TITLE
wait for ipc message to be received

### DIFF
--- a/packages/backend/src/daemons/verify.mjs
+++ b/packages/backend/src/daemons/verify.mjs
@@ -31,12 +31,16 @@ try {
     process.send(mpcParams)
     process.exit(0)
   }
-  process.send({
+  const sent = process.send({
     contributions: mpcParams.contributions.map((c) => ({
       contributionHash: formatHash(c.contributionHash),
       name: c.name,
     })),
   })
+  if (!sent) {
+    console.log('failed to send ipc message')
+  }
+  await new Promise(r => setTimeout(r, 2000))
   process.exit(0)
 } catch (err) {
   console.log(err)

--- a/packages/backend/src/daemons/verify.mjs
+++ b/packages/backend/src/daemons/verify.mjs
@@ -40,7 +40,7 @@ try {
   if (!sent) {
     console.log('failed to send ipc message')
   }
-  await new Promise(r => setTimeout(r, 2000))
+  await new Promise((r) => setTimeout(r, 2000))
   process.exit(0)
 } catch (err) {
   console.log(err)


### PR DESCRIPTION
As there are more contributions to a circuit the mpc params are larger and take longer to move over ipc. This was causing a race condition between the child process exiting and the ipc message being received. Added a simple delay to exiting the child process to ensure the ipc message is received and processed.

This also partially fixes the disk space usage problem. Fewer rejected contributions means fewer uploads that get left in the temporary directory.

I applied this change on the server manually but we should pull it in here.