### PR TITLE
fix: silently fail to send 500 in error handler

### DIFF
--- a/packages/backend/src/catchError.mjs
+++ b/packages/backend/src/catchError.mjs
@@ -4,7 +4,11 @@ export const catchError = (fn) => async (req, res, next) => {
   } catch (err) {
     console.log('Uncaught error in http handler')
     console.log(err)
-    res.status(500).end({ error: 'uncaught error' })
+    try {
+      // try to send a 500
+      // the response has already started just silently fail
+      res.status(500).end({ error: 'uncaught error' })
+    } catch (_) {}
   }
 }
 


### PR DESCRIPTION
The backup system deletes old zkeys once they have been backed up. If there is a connection actively downloading the zkey when it is deleted the server will crash because the error handler tries to send a 500 response after a partial response has been sent. This PR fixes the problem by silently failing to send a 500 if the response has partially been sent.