### PR TITLE
refactor: write verification data to filesystem instead of ipc

### DIFF
--- a/packages/backend/src/daemons/verifyParallel.mjs
+++ b/packages/backend/src/daemons/verifyParallel.mjs
@@ -26,14 +26,17 @@ class ThreadManager {
           let receivedMsg = false
           p.on('message', async (msg) => {
             try {
+              receivedMsg = true
               const { filepath } = msg
               const data = await fs.readFile(filepath)
               rs(JSON.parse(data.toString()))
-              receivedMsg = true
-              await fs.rm(filepath)
+              fs.rm(filepath).catch((err) =>
+                console.log(`Error deleting json verification file`, err)
+              )
             } catch (err) {
               console.log('unexpected error in verifier message handler')
               console.log(err)
+              rj(err)
             }
           })
           p.on('exit', (code) => {

--- a/packages/backend/src/daemons/verifyParallel.mjs
+++ b/packages/backend/src/daemons/verifyParallel.mjs
@@ -2,6 +2,7 @@ import os from 'os'
 import child_process from 'child_process'
 import url from 'url'
 import path from 'path'
+import fs from 'fs/promises'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
@@ -23,9 +24,17 @@ class ThreadManager {
         new Promise((rs, rj) => {
           const p = child_process.fork(path.join(__dirname, 'verify.mjs'), args)
           let receivedMsg = false
-          p.on('message', (msg) => {
-            receivedMsg = true
-            rs(msg)
+          p.on('message', async (msg) => {
+            try {
+              const { filepath } = msg
+              const data = await fs.readFile(filepath)
+              rs(JSON.parse(data.toString()))
+              receivedMsg = true
+              await fs.rm(filepath)
+            } catch (err) {
+              console.log('unexpected error in verifier message handler')
+              console.log(err)
+            }
           })
           p.on('exit', (code) => {
             if (!receivedMsg && code === 0) {


### PR DESCRIPTION
IPC communication is failing now that we have a few thousand contributions. It's better to move the data over the tcp or the filesystem. This refactor writes to a temporary file and sends the file location over ipc instead of writing the data directly over ipc.