### PR TITLE
fix: backup race condition

### DIFF
--- a/packages/backend/src/daemons/backup.mjs
+++ b/packages/backend/src/daemons/backup.mjs
@@ -61,7 +61,7 @@ export default class Backup {
       const toUpload = await this.db.findMany('Contribution', {
         where: {
           circuitName: circuit.name,
-          _id: { ne: latest._id },
+          createdAt: { lt: latest.createdAt },
           uploadedAt: null,
         },
       })


### PR DESCRIPTION
If a new contribution is created between when the `latest` contribution is queried and when the `toUpload` contributions are queried, the _new_ contribution will be uploaded and then deleted. In the next backup pass the old latest contribution will then be uploaded and deleted leaving no keys on the server.

Closes #22 