### PR TITLE
Homepage UI modification after ceremony closed.

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,1 +1,2 @@
 HTTP_SERVER='https://dev2.http.ceremony.unirep.io'
+ENDS_AT=

--- a/packages/frontend/src/components/Countdown.jsx
+++ b/packages/frontend/src/components/Countdown.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
+import { ENDS_AT } from '../config.js'
 import './countdown.css'
 
 export default observer(() => {
   const [remainTime, setRemainTime] = React.useState([0, 0, 0, 0])
+  const dday = new Date(ENDS_AT)
 
   const updateTimer = async () => {
-    const dday = new Date(Date.UTC(2023, 11, 12, 0, 0, 0))
     const now = Date.now()
     let dSeconds = Math.floor((dday - now) / 1000)
     const dDays = Math.floor(dSeconds / (24 * 60 * 60))

--- a/packages/frontend/src/components/Countdown.jsx
+++ b/packages/frontend/src/components/Countdown.jsx
@@ -1,47 +1,52 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
-import { ENDS_AT } from '../config.js'
+import state from '../contexts/state'
 import './countdown.css'
 
 export default observer(() => {
+  const { ui } = React.useContext(state)
   const [remainTime, setRemainTime] = React.useState([0, 0, 0, 0])
-  const dday = new Date(ENDS_AT)
 
   const updateTimer = async () => {
-    const now = Date.now()
-    let dSeconds = Math.floor((dday - now) / 1000)
-    const dDays = Math.floor(dSeconds / (24 * 60 * 60))
-    dSeconds -= dDays * 24 * 60 * 60
-    const dHours = Math.floor(dSeconds / (60 * 60))
-    dSeconds -= dHours * 60 * 60
-    const dMinutes = Math.floor(dSeconds / 60)
-    dSeconds -= dMinutes * 60
-    setRemainTime([dDays, dHours, dMinutes, dSeconds])
+    if (ui.endsIn > 0) {
+      let dSeconds = Math.floor(ui.endsIn / 1000)
+      const dDays = Math.floor(dSeconds / (24 * 60 * 60))
+      dSeconds -= dDays * 24 * 60 * 60
+      const dHours = Math.floor(dSeconds / (60 * 60))
+      dSeconds -= dHours * 60 * 60
+      const dMinutes = Math.floor(dSeconds / 60)
+      dSeconds -= dMinutes * 60
+      setRemainTime([dDays, dHours, dMinutes, dSeconds])
+    }
   }
 
   React.useEffect(() => {
-    setInterval(() => {
-      updateTimer()
-    }, 1000)
-  }, [])
+    updateTimer()
+  }, [ui.endsIn])
 
   return (
-    <div className="countdown-container">
-      <div className="countdown-time">
-        {remainTime[0].toString().padStart(2, '0')}d
-      </div>
-      <div>:</div>
-      <div className="countdown-time">
-        {remainTime[1].toString().padStart(2, '0')}h
-      </div>
-      <div>:</div>
-      <div className="countdown-time">
-        {remainTime[2].toString().padStart(2, '0')}m
-      </div>
-      <div>:</div>
-      <div className="countdown-time">
-        {remainTime[3].toString().padStart(2, '0')}s
-      </div>
-    </div>
+    <>
+      {ui.endsIn > 0 ? (
+        <div className="countdown-container">
+          <div className="countdown-time">
+            {remainTime[0].toString().padStart(2, '0')}d
+          </div>
+          <div>:</div>
+          <div className="countdown-time">
+            {remainTime[1].toString().padStart(2, '0')}h
+          </div>
+          <div>:</div>
+          <div className="countdown-time">
+            {remainTime[2].toString().padStart(2, '0')}m
+          </div>
+          <div>:</div>
+          <div className="countdown-time">
+            {remainTime[3].toString().padStart(2, '0')}s
+          </div>
+        </div>
+      ) : (
+        <h3>The cosmic call has ended. Thank you.</h3>
+      )}
+    </>
   )
 })

--- a/packages/frontend/src/components/Header.jsx
+++ b/packages/frontend/src/components/Header.jsx
@@ -43,9 +43,11 @@ export default observer(({ logoOnly, disableLink }) => {
 
           <div className="header-flex" style={{ justifyContent: 'flex-end' }}>
             <Link to="/stats">Stats</Link>
-            <div className="header-button">
-              <Link to="/contribute">Contribute</Link>
-            </div>
+            {ui.endsIn > 0 && (
+              <div className="header-button">
+                <Link to="/contribute">Contribute</Link>
+              </div>
+            )}
           </div>
         </div>
       )}{' '}

--- a/packages/frontend/src/components/Menu.jsx
+++ b/packages/frontend/src/components/Menu.jsx
@@ -6,7 +6,7 @@ import './menu.css'
 import state from '../contexts/state'
 
 export default observer(({ closeMenu }) => {
-  const { ceremony } = useContext(state)
+  const { ceremony, ui } = useContext(state)
   return (
     <div className="menu-container">
       <div className="header">
@@ -33,9 +33,11 @@ export default observer(({ closeMenu }) => {
       <div className="menu-content">
         <Link to="/stats">Stats</Link>
 
-        <div className="menu-contribute">
-          <Link to="/contribute">Contribute</Link>
-        </div>
+        {ui.endsIn > 0 && (
+          <div className="menu-contribute">
+            <Link to="/contribute">Contribute</Link>
+          </div>
+        )}
 
         <ServerState shrink={true} />
 

--- a/packages/frontend/src/config.js
+++ b/packages/frontend/src/config.js
@@ -5,5 +5,5 @@ export const HTTP_SERVER = process.env.HTTP_SERVER
   : null
 
 export const ENDS_AT = process.env.ENDS_AT
-  ? parseInt(process.env.ENDS_AT)
-  : 10 ** 13
+  ? new Date(parseInt(process.env.ENDS_AT))
+  : new Date(10 ** 13)

--- a/packages/frontend/src/config.js
+++ b/packages/frontend/src/config.js
@@ -3,3 +3,7 @@ export const HTTP_SERVER = process.env.HTTP_SERVER
     ? process.env.HTTP_SERVER
     : `https://${process.env.HTTP_SERVER}`
   : null
+
+export const ENDS_AT = process.env.ENDS_AT
+  ? parseInt(process.env.ENDS_AT)
+  : 10 ** 13

--- a/packages/frontend/src/contexts/interface.js
+++ b/packages/frontend/src/contexts/interface.js
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
 import { makeAutoObservable } from 'mobx'
+import { ENDS_AT } from '../config.js'
 
 const MAX_MOBILE_WIDTH = 850
 
@@ -12,6 +13,7 @@ export default class Interface {
   screenHeight = -1
   isMobile = false
   loaded = false
+  endsIn = ENDS_AT - Date.now()
 
   constructor(state, requestUrl) {
     makeAutoObservable(this)
@@ -38,6 +40,9 @@ export default class Interface {
     window.addEventListener('load', () => {
       this.loaded = true
     })
+    setInterval(() => {
+      this.endsIn = ENDS_AT - Date.now()
+    }, 1000)
   }
 
   updateWindowSize() {

--- a/packages/frontend/src/pages/Home.jsx
+++ b/packages/frontend/src/pages/Home.jsx
@@ -48,16 +48,29 @@ export default observer(() => {
             Do you hear the cosmic call? The ceremony will end in:
           </div>
           <Countdown />
-          <div className="flex-center">
-            <Link to="/contribute">
-              <div className="hero-button">Open Chapter (GUI)</div>
-            </Link>
-          </div>
-          <div className="flex-center">
-            <Link to="/contribute#cli">
-              <div className="hero-button-inverse">Use CLI</div>
-            </Link>
-          </div>
+          {ui.endsIn > 0 && (
+            <div className="flex-center">
+              <Link to="/contribute">
+                <div className="hero-button">Open Chapter (GUI)</div>
+              </Link>
+            </div>
+          )}
+          {ui.endsIn > 0 && (
+            <div className="flex-center">
+              <Link to="/contribute#cli">
+                <div className="hero-button-inverse">Use CLI</div>
+              </Link>
+            </div>
+          )}
+          {ui.endsIn <= 0 && (
+            <div className="flex-center">
+              <Link to="/stats">
+                <div className="hero-button-inverse">
+                  View all contributions
+                </div>
+              </Link>
+            </div>
+          )}
         </div>
 
         <InfoContainer


### PR DESCRIPTION
- let `ENDS_AT` be a environment variable
- move `endsIn` (which is the remaining time for closing the ceremony) to `Interface` context, since it will affect several UI components
- follow the design on figma:
  - if closed, add `h3` text to inform the ceremony is closed.
  - change the hero button to only lead to the `/stats`